### PR TITLE
Fix - Fetching rich text content with circular references

### DIFF
--- a/src/Node/EmbeddedEntryBlock.php
+++ b/src/Node/EmbeddedEntryBlock.php
@@ -12,28 +12,30 @@ declare(strict_types=1);
 namespace Contentful\RichText\Node;
 
 use Contentful\Core\Resource\EntryInterface;
+use Contentful\RichText\NodeMapper\Reference\EntryReferenceInterface;
 
 class EmbeddedEntryBlock extends BlockNode
 {
     /**
-     * @var EntryInterface
+     * @var EntryReferenceInterface
      */
-    protected $entry;
+    protected $reference;
 
     /**
      * EmbeddedEntryBlock constructor.
      *
      * @param NodeInterface[] $content
+     * @param EntryReferenceInterface $reference
      */
-    public function __construct(array $content, EntryInterface $entry)
+    public function __construct(array $content, EntryReferenceInterface $reference)
     {
         parent::__construct($content);
-        $this->entry = $entry;
+        $this->reference = $reference;
     }
 
     public function getEntry(): EntryInterface
     {
-        return $this->entry;
+        return $this->reference->getEntry();
     }
 
     /**
@@ -52,7 +54,7 @@ class EmbeddedEntryBlock extends BlockNode
         return [
             'nodeType' => self::getType(),
             'data' => [
-                'target' => $this->entry->asLink(),
+                'target' => $this->reference,
             ],
             'content' => $this->content,
         ];

--- a/src/Node/EmbeddedEntryInline.php
+++ b/src/Node/EmbeddedEntryInline.php
@@ -12,28 +12,31 @@ declare(strict_types=1);
 namespace Contentful\RichText\Node;
 
 use Contentful\Core\Resource\EntryInterface;
+use Contentful\RichText\NodeMapper\Reference\EntryReferenceInterface;
 
 class EmbeddedEntryInline extends InlineNode
 {
+
     /**
-     * @var EntryInterface
+     * @var EntryReferenceInterface
      */
-    protected $entry;
+    protected $reference;
 
     /**
      * EmbeddedEntryInline constructor.
      *
      * @param NodeInterface[] $content
+     * @param EntryReferenceInterface $reference
      */
-    public function __construct(array $content, EntryInterface $entry)
+    public function __construct(array $content, EntryReferenceInterface $reference)
     {
         parent::__construct($content);
-        $this->entry = $entry;
+        $this->reference = $reference;
     }
 
     public function getEntry(): EntryInterface
     {
-        return $this->entry;
+        return $this->reference->getEntry();
     }
 
     /**
@@ -52,7 +55,7 @@ class EmbeddedEntryInline extends InlineNode
         return [
             'nodeType' => self::getType(),
             'data' => [
-                'target' => $this->entry->asLink(),
+                'target' => $this->reference,
             ],
             'content' => $this->content,
         ];

--- a/src/Node/EntryHyperlink.php
+++ b/src/Node/EntryHyperlink.php
@@ -11,9 +11,8 @@ declare(strict_types=1);
 
 namespace Contentful\RichText\Node;
 
-use Contentful\Core\Api\Link;
-use Contentful\Core\Api\LinkResolverInterface;
 use Contentful\Core\Resource\EntryInterface;
+use Contentful\RichText\NodeMapper\Reference\EntryReferenceInterface;
 
 class EntryHyperlink extends InlineNode
 {
@@ -23,35 +22,22 @@ class EntryHyperlink extends InlineNode
     protected $title;
 
     /**
-     * @var EntryInterface
+     * @var EntryReferenceInterface
      */
-    protected $entry;
-
-    /**
-     * @var \Contentful\Core\Api\Link
-     */
-    private $link;
-
-    /**
-     * @var \Contentful\Core\Api\LinkResolverInterface
-     */
-    private $linkResolver;
+    protected $reference;
 
     /**
      * AssetHyperlink constructor.
      *
      * @param NodeInterface[] $content
      * @param string $title
-     * @param \Contentful\Core\Api\Link $link
-     * @param \Contentful\Core\Api\LinkResolverInterface $linkResolver
+     * @param EntryReferenceInterface $reference
      */
-    public function __construct(array $content, string $title, Link $link, LinkResolverInterface $linkResolver)
+    public function __construct(array $content, string $title, EntryReferenceInterface $reference)
     {
         parent::__construct($content);
         $this->title = $title;
-        $this->entry = null;
-        $this->link = $link;
-        $this->linkResolver = $linkResolver;
+        $this->reference = $reference;
     }
 
     /**
@@ -59,10 +45,7 @@ class EntryHyperlink extends InlineNode
      */
     public function getEntry(): EntryInterface
     {
-        if (is_null($this->entry)) {
-            $this->entry = $this->linkResolver->resolveLink($this->link);
-        }
-        return $this->entry;
+        return $this->reference->getEntry();
     }
 
     public function getTitle(): string
@@ -87,7 +70,7 @@ class EntryHyperlink extends InlineNode
             'nodeType' => self::getType(),
             'data' => [
                 'title' => $this->title,
-                'target' => $this->link,
+                'target' => $this->reference,
             ],
             'content' => $this->content,
         ];

--- a/src/Node/EntryHyperlink.php
+++ b/src/Node/EntryHyperlink.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Contentful\RichText\Node;
 
+use Contentful\Core\Api\Link;
+use Contentful\Core\Api\LinkResolverInterface;
 use Contentful\Core\Resource\EntryInterface;
 
 class EntryHyperlink extends InlineNode
@@ -26,19 +28,40 @@ class EntryHyperlink extends InlineNode
     protected $entry;
 
     /**
+     * @var \Contentful\Core\Api\Link
+     */
+    private $link;
+
+    /**
+     * @var \Contentful\Core\Api\LinkResolverInterface
+     */
+    private $linkResolver;
+
+    /**
      * AssetHyperlink constructor.
      *
      * @param NodeInterface[] $content
+     * @param string $title
+     * @param \Contentful\Core\Api\Link $link
+     * @param \Contentful\Core\Api\LinkResolverInterface $linkResolver
      */
-    public function __construct(array $content, EntryInterface $entry, string $title)
+    public function __construct(array $content, string $title, Link $link, LinkResolverInterface $linkResolver)
     {
         parent::__construct($content);
-        $this->entry = $entry;
         $this->title = $title;
+        $this->entry = null;
+        $this->link = $link;
+        $this->linkResolver = $linkResolver;
     }
 
+    /**
+     * @return EntryInterface
+     */
     public function getEntry(): EntryInterface
     {
+        if (is_null($this->entry)) {
+            $this->entry = $this->linkResolver->resolveLink($this->link);
+        }
         return $this->entry;
     }
 
@@ -64,7 +87,7 @@ class EntryHyperlink extends InlineNode
             'nodeType' => self::getType(),
             'data' => [
                 'title' => $this->title,
-                'target' => $this->entry->asLink(),
+                'target' => $this->link,
             ],
             'content' => $this->content,
         ];

--- a/src/NodeMapper/EmbeddedEntryBlock.php
+++ b/src/NodeMapper/EmbeddedEntryBlock.php
@@ -13,10 +13,9 @@ namespace Contentful\RichText\NodeMapper;
 
 use Contentful\Core\Api\Link;
 use Contentful\Core\Api\LinkResolverInterface;
-use Contentful\Core\Resource\EntryInterface;
-use Contentful\RichText\Exception\MapperException;
 use Contentful\RichText\Node\EmbeddedEntryBlock as NodeClass;
 use Contentful\RichText\Node\NodeInterface;
+use Contentful\RichText\NodeMapper\Reference\EntryReference;
 use Contentful\RichText\ParserInterface;
 
 class EmbeddedEntryBlock implements NodeMapperInterface
@@ -28,18 +27,12 @@ class EmbeddedEntryBlock implements NodeMapperInterface
     {
         $linkData = $data['data']['target']['sys'];
 
-        try {
-            /** @var EntryInterface $entry */
-            $entry = $linkResolver->resolveLink(
-                new Link($linkData['id'], $linkData['linkType'])
-            );
-        } catch (\Throwable $exception) {
-            throw new MapperException($data);
-        }
-
         return new NodeClass(
             $parser->parseCollection($data['content']),
-            $entry
+            new EntryReference(
+                new Link($linkData['id'], $linkData['linkType']),
+                $linkResolver
+            )
         );
     }
 }

--- a/src/NodeMapper/EmbeddedEntryInline.php
+++ b/src/NodeMapper/EmbeddedEntryInline.php
@@ -13,10 +13,9 @@ namespace Contentful\RichText\NodeMapper;
 
 use Contentful\Core\Api\Link;
 use Contentful\Core\Api\LinkResolverInterface;
-use Contentful\Core\Resource\EntryInterface;
-use Contentful\RichText\Exception\MapperException;
 use Contentful\RichText\Node\EmbeddedEntryInline as NodeClass;
 use Contentful\RichText\Node\NodeInterface;
+use Contentful\RichText\NodeMapper\Reference\EntryReference;
 use Contentful\RichText\ParserInterface;
 
 class EmbeddedEntryInline implements NodeMapperInterface
@@ -28,18 +27,12 @@ class EmbeddedEntryInline implements NodeMapperInterface
     {
         $linkData = $data['data']['target']['sys'];
 
-        try {
-            /** @var EntryInterface $entry */
-            $entry = $linkResolver->resolveLink(
-                new Link($linkData['id'], $linkData['linkType'])
-            );
-        } catch (\Throwable $exception) {
-            throw new MapperException($data);
-        }
-
         return new NodeClass(
             $parser->parseCollection($data['content']),
-            $entry
+            new EntryReference(
+                new Link($linkData['id'], $linkData['linkType']),
+                $linkResolver
+            )
         );
     }
 }

--- a/src/NodeMapper/EntryHyperlink.php
+++ b/src/NodeMapper/EntryHyperlink.php
@@ -13,8 +13,6 @@ namespace Contentful\RichText\NodeMapper;
 
 use Contentful\Core\Api\Link;
 use Contentful\Core\Api\LinkResolverInterface;
-use Contentful\Core\Resource\EntryInterface;
-use Contentful\RichText\Exception\MapperException;
 use Contentful\RichText\Node\EntryHyperlink as NodeClass;
 use Contentful\RichText\Node\NodeInterface;
 use Contentful\RichText\ParserInterface;
@@ -28,19 +26,11 @@ class EntryHyperlink implements NodeMapperInterface
     {
         $linkData = $data['data']['target']['sys'];
 
-        try {
-            /** @var EntryInterface $entry */
-            $entry = $linkResolver->resolveLink(
-                new Link($linkData['id'], $linkData['linkType'])
-            );
-        } catch (\Throwable $exception) {
-            throw new MapperException($data);
-        }
-
         return new NodeClass(
             $parser->parseCollection($data['content']),
-            $entry,
-            $data['data']['title'] ?? ''
+            $data['data']['title'] ?? '',
+            new Link($linkData['id'], $linkData['linkType']),
+            $linkResolver
         );
     }
 }

--- a/src/NodeMapper/EntryHyperlink.php
+++ b/src/NodeMapper/EntryHyperlink.php
@@ -15,6 +15,7 @@ use Contentful\Core\Api\Link;
 use Contentful\Core\Api\LinkResolverInterface;
 use Contentful\RichText\Node\EntryHyperlink as NodeClass;
 use Contentful\RichText\Node\NodeInterface;
+use Contentful\RichText\NodeMapper\Reference\EntryReference;
 use Contentful\RichText\ParserInterface;
 
 class EntryHyperlink implements NodeMapperInterface
@@ -29,8 +30,10 @@ class EntryHyperlink implements NodeMapperInterface
         return new NodeClass(
             $parser->parseCollection($data['content']),
             $data['data']['title'] ?? '',
-            new Link($linkData['id'], $linkData['linkType']),
-            $linkResolver
+            new EntryReference(
+                new Link($linkData['id'], $linkData['linkType']),
+                $linkResolver
+            )
         );
     }
 }

--- a/src/NodeMapper/Reference/EntryReference.php
+++ b/src/NodeMapper/Reference/EntryReference.php
@@ -1,0 +1,60 @@
+<?php
+namespace Contentful\RichText\NodeMapper\Reference;
+
+use Contentful\Core\Api\Link;
+use Contentful\Core\Api\LinkResolverInterface;
+use Contentful\Core\Resource\EntryInterface;
+use InvalidArgumentException;
+
+class EntryReference implements EntryReferenceInterface
+{
+    /**
+     * @var Link
+     */
+    private $link;
+
+    /**
+     * @var LinkResolverInterface
+     */
+    private $linkResolver;
+
+    /**
+     * @var EntryInterface
+     */
+    private $entry;
+
+    /**
+     * EntryReference constructor.
+     *
+     * @param Link $link
+     * @param LinkResolverInterface $linkResolver
+     */
+    public function __construct(Link $link, LinkResolverInterface $linkResolver)
+    {
+        if ($link->getLinkType() !== 'Entry') {
+            throw new InvalidArgumentException('Link is required to reference an Entry.');
+        }
+
+        $this->entry = null;
+        $this->link = $link;
+        $this->linkResolver = $linkResolver;
+    }
+
+    public function getLink(): Link
+    {
+        return $this->link;
+    }
+
+    public function getEntry(): EntryInterface
+    {
+        if (is_null($this->entry)) {
+            $this->entry = $this->linkResolver->resolveLink($this->link);
+        }
+        return $this->entry;
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->link->jsonSerialize();
+    }
+}

--- a/src/NodeMapper/Reference/EntryReferenceInterface.php
+++ b/src/NodeMapper/Reference/EntryReferenceInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace Contentful\RichText\NodeMapper\Reference;
+
+use Contentful\Core\Resource\EntryInterface;
+use JsonSerializable;
+
+interface EntryReferenceInterface extends JsonSerializable
+{
+    public function getEntry(): EntryInterface;
+}

--- a/src/NodeMapper/Reference/StaticEntryReference.php
+++ b/src/NodeMapper/Reference/StaticEntryReference.php
@@ -1,0 +1,36 @@
+<?php
+namespace Contentful\RichText\NodeMapper\Reference;
+
+use Contentful\Core\Api\Link;
+use Contentful\Core\Resource\EntryInterface;
+
+class StaticEntryReference implements EntryReferenceInterface
+{
+    /** @var EntryInterface */
+    private $entry;
+
+    /**
+     * StaticEntryReference constructor.
+     *
+     * @param EntryInterface $entry
+     */
+    public function __construct(EntryInterface $entry)
+    {
+        $this->entry = $entry;
+    }
+
+    public function getLink(): Link
+    {
+        return $this->entry->asLink();
+    }
+
+    public function getEntry(): EntryInterface
+    {
+        return $this->entry;
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->entry->asLink()->jsonSerialize();
+    }
+}

--- a/tests/Unit/Node/EmbeddedEntryBlockTest.php
+++ b/tests/Unit/Node/EmbeddedEntryBlockTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Contentful\Tests\RichText\Unit\Node;
 
 use Contentful\RichText\Node\EmbeddedEntryBlock;
+use Contentful\RichText\NodeMapper\Reference\StaticEntryReference;
 use Contentful\Tests\RichText\Implementation\Entry;
 use Contentful\Tests\RichText\TestCase;
 
@@ -23,7 +24,7 @@ class EmbeddedEntryBlockTest extends TestCase
 
         $nodes = $this->createNodes(5);
         $entry = new Entry('entryId');
-        $node = new EmbeddedEntryBlock($nodes, $entry);
+        $node = new EmbeddedEntryBlock($nodes, new StaticEntryReference($entry));
 
         $this->assertSame($nodes, $node->getContent());
         $this->assertSame($entry, $node->getEntry());

--- a/tests/Unit/Node/EmbeddedEntryInlineTest.php
+++ b/tests/Unit/Node/EmbeddedEntryInlineTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Contentful\Tests\RichText\Unit\Node;
 
 use Contentful\RichText\Node\EmbeddedEntryInline;
+use Contentful\RichText\NodeMapper\Reference\StaticEntryReference;
 use Contentful\Tests\RichText\Implementation\Entry;
 use Contentful\Tests\RichText\TestCase;
 
@@ -23,7 +24,7 @@ class EmbeddedEntryInlineTest extends TestCase
 
         $nodes = $this->createNodes(5);
         $entry = new Entry('entryId');
-        $node = new EmbeddedEntryInline($nodes, $entry);
+        $node = new EmbeddedEntryInline($nodes, new StaticEntryReference($entry));
 
         $this->assertSame($nodes, $node->getContent());
         $this->assertSame($entry, $node->getEntry());

--- a/tests/Unit/Node/EntryHyperlinkTest.php
+++ b/tests/Unit/Node/EntryHyperlinkTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Contentful\Tests\RichText\Unit\Node;
 
 use Contentful\RichText\Node\EntryHyperlink;
+use Contentful\RichText\NodeMapper\Reference\StaticEntryReference;
 use Contentful\Tests\RichText\Implementation\Entry;
 use Contentful\Tests\RichText\TestCase;
 
@@ -23,7 +24,7 @@ class EntryHyperlinkTest extends TestCase
 
         $nodes = $this->createNodes(1);
         $entry = new Entry('entryId');
-        $node = new EntryHyperlink($nodes, $entry, 'Entry link');
+        $node = new EntryHyperlink($nodes, 'Entry link', new StaticEntryReference($entry));
 
         $this->assertSame($nodes, $node->getContent());
         $this->assertSame($entry, $node->getEntry());

--- a/tests/Unit/NodeRenderer/EmbeddedEntryBlockTest.php
+++ b/tests/Unit/NodeRenderer/EmbeddedEntryBlockTest.php
@@ -13,6 +13,7 @@ namespace Contentful\Tests\RichText\Unit\NodeRenderer;
 
 use Contentful\Core\Api\Link;
 use Contentful\RichText\Node\EmbeddedEntryBlock as NodeClass;
+use Contentful\RichText\NodeMapper\Reference\EntryReference;
 use Contentful\RichText\NodeRenderer\EmbeddedEntryBlock;
 use Contentful\Tests\RichText\Implementation\LinkResolver;
 use Contentful\Tests\RichText\Implementation\Node;
@@ -26,7 +27,8 @@ class EmbeddedEntryBlockTest extends TestCase
         $renderer = new Renderer();
         $nodeRenderer = new EmbeddedEntryBlock();
 
-        $node = new NodeClass([], new Link('entryId', 'Entry'), new LinkResolver());
+        $reference = new EntryReference(new Link('entryId', 'Entry'), new LinkResolver());
+        $node = new NodeClass([], $reference);
 
         $this->assertTrue($nodeRenderer->supports($node));
         $this->assertFalse($nodeRenderer->supports(new Node('Some value')));

--- a/tests/Unit/NodeRenderer/EmbeddedEntryBlockTest.php
+++ b/tests/Unit/NodeRenderer/EmbeddedEntryBlockTest.php
@@ -11,9 +11,10 @@ declare(strict_types=1);
 
 namespace Contentful\Tests\RichText\Unit\NodeRenderer;
 
+use Contentful\Core\Api\Link;
 use Contentful\RichText\Node\EmbeddedEntryBlock as NodeClass;
 use Contentful\RichText\NodeRenderer\EmbeddedEntryBlock;
-use Contentful\Tests\RichText\Implementation\Entry;
+use Contentful\Tests\RichText\Implementation\LinkResolver;
 use Contentful\Tests\RichText\Implementation\Node;
 use Contentful\Tests\RichText\Implementation\Renderer;
 use Contentful\Tests\RichText\TestCase;
@@ -24,7 +25,8 @@ class EmbeddedEntryBlockTest extends TestCase
     {
         $renderer = new Renderer();
         $nodeRenderer = new EmbeddedEntryBlock();
-        $node = new NodeClass([], new Entry('entryId'));
+
+        $node = new NodeClass([], new Link('entryId', 'Entry'), new LinkResolver());
 
         $this->assertTrue($nodeRenderer->supports($node));
         $this->assertFalse($nodeRenderer->supports(new Node('Some value')));

--- a/tests/Unit/NodeRenderer/EmbeddedEntryInlineTest.php
+++ b/tests/Unit/NodeRenderer/EmbeddedEntryInlineTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Contentful\Tests\RichText\Unit\NodeRenderer;
 
 use Contentful\RichText\Node\EmbeddedEntryInline as NodeClass;
+use Contentful\RichText\NodeMapper\Reference\StaticEntryReference;
 use Contentful\RichText\NodeRenderer\EmbeddedEntryInline;
 use Contentful\Tests\RichText\Implementation\Entry;
 use Contentful\Tests\RichText\Implementation\Node;
@@ -24,7 +25,7 @@ class EmbeddedEntryInlineTest extends TestCase
     {
         $renderer = new Renderer();
         $nodeRenderer = new EmbeddedEntryInline();
-        $node = new NodeClass([], new Entry('entryId'));
+        $node = new NodeClass([], new StaticEntryReference(new Entry('entryId')));
 
         $this->assertTrue($nodeRenderer->supports($node));
         $this->assertFalse($nodeRenderer->supports(new Node('Some value')));

--- a/tests/Unit/NodeRenderer/EntryHyperlinkTest.php
+++ b/tests/Unit/NodeRenderer/EntryHyperlinkTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Contentful\Tests\RichText\Unit\NodeRenderer;
 
 use Contentful\RichText\Node\EntryHyperlink as NodeClass;
+use Contentful\RichText\NodeMapper\Reference\StaticEntryReference;
 use Contentful\RichText\NodeRenderer\EntryHyperlink;
 use Contentful\Tests\RichText\Implementation\Entry;
 use Contentful\Tests\RichText\Implementation\Node;
@@ -25,7 +26,7 @@ class EntryHyperlinkTest extends TestCase
         $renderer = new Renderer();
         $nodeRenderer = new EntryHyperlink();
         $nodes = $this->createNodes(1);
-        $node = new NodeClass($nodes, new Entry('entryId'), 'Entry title');
+        $node = new NodeClass($nodes, 'Entry title', new StaticEntryReference(new Entry('entryId')));
 
         $this->assertTrue($nodeRenderer->supports($node));
         $this->assertFalse($nodeRenderer->supports(new Node('Some value')));

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -117,9 +117,6 @@ class ParserTest extends TestCase
             ['asset-hyperlink'],
             ['embedded-asset-block'],
             ['embedded-asset-inline'],
-            ['embedded-entry-block'],
-            ['embedded-entry-inline'],
-            ['entry-hyperlink'],
         ];
     }
 

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -111,12 +111,39 @@ class ParserTest extends TestCase
         $this->assertJsonFixtureEqualsJsonObject($file.'.json', $node);
     }
 
+    /**
+     * @dataProvider provideInvalidDeferredResolvedLinkNodes
+     */
+    public function testMapperDeferredReferenceResolution(string $file, string $nodeClass)
+    {
+        $parser = new Parser(new FailingLinkResolver());
+
+        /** @var NodeClass\EntryHyperlink|NodeClass\EmbeddedEntryBlock|NodeClass\EmbeddedEntryInline $node */
+        $node = $parser->parse($this->getParsedFixture($file.'.json'));
+
+        $this->assertInstanceOf($nodeClass, $node);
+
+        /** @see FailingLinkResolver::resolveLink */
+        $this->expectException(\Exception::class);
+
+        $node->getEntry();
+    }
+
     public function provideInvalidLinkNodes(): array
     {
         return [
             ['asset-hyperlink'],
             ['embedded-asset-block'],
             ['embedded-asset-inline'],
+        ];
+    }
+
+    public function provideInvalidDeferredResolvedLinkNodes(): array
+    {
+        return [
+            ['embedded-entry-block', NodeClass\EmbeddedEntryBlock::class],
+            ['embedded-entry-inline', NodeClass\EmbeddedEntryInline::class],
+            ['entry-hyperlink', NodeClass\EntryHyperlink::class],
         ];
     }
 


### PR DESCRIPTION
- Fixes #43 by postponing link resolution to when the embedded entry is actually requested
- Fixes #44 by dropping the catch-all statement