### PR TITLE
Fix/php 122 multiple objects circular reference

### DIFF
--- a/src/Bridge/PlatesExtension.php
+++ b/src/Bridge/PlatesExtension.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Bridge/TwigExtension.php
+++ b/src/Bridge/TwigExtension.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Exception/MapperException.php
+++ b/src/Exception/MapperException.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Mark/Bold.php
+++ b/src/Mark/Bold.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Mark/Code.php
+++ b/src/Mark/Code.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Mark/Italic.php
+++ b/src/Mark/Italic.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Mark/MarkInterface.php
+++ b/src/Mark/MarkInterface.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Mark/Underline.php
+++ b/src/Mark/Underline.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/AssetHyperlink.php
+++ b/src/Node/AssetHyperlink.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/BlockNode.php
+++ b/src/Node/BlockNode.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/Blockquote.php
+++ b/src/Node/Blockquote.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/Document.php
+++ b/src/Node/Document.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/EmbeddedAssetBlock.php
+++ b/src/Node/EmbeddedAssetBlock.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/EmbeddedAssetInline.php
+++ b/src/Node/EmbeddedAssetInline.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/EmbeddedEntryBlock.php
+++ b/src/Node/EmbeddedEntryBlock.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Contentful\RichText\Node;
 
-use Contentful\Core\Resource\EntryInterface;
+use Contentful\Core\Resource\ResourceInterface;
 use Contentful\RichText\NodeMapper\Reference\EntryReferenceInterface;
 
 class EmbeddedEntryBlock extends BlockNode
@@ -32,7 +32,7 @@ class EmbeddedEntryBlock extends BlockNode
         $this->reference = $reference;
     }
 
-    public function getEntry(): EntryInterface
+    public function getEntry(): ResourceInterface
     {
         return $this->reference->getEntry();
     }

--- a/src/Node/EmbeddedEntryBlock.php
+++ b/src/Node/EmbeddedEntryBlock.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Contentful\RichText\Node;
 
-use Contentful\Core\Resource\ResourceInterface;
+use Contentful\Core\Resource\EntryInterface;
 use Contentful\RichText\NodeMapper\Reference\EntryReferenceInterface;
 
 class EmbeddedEntryBlock extends BlockNode
@@ -32,7 +32,7 @@ class EmbeddedEntryBlock extends BlockNode
         $this->reference = $reference;
     }
 
-    public function getEntry(): ResourceInterface
+    public function getEntry(): EntryInterface
     {
         return $this->reference->getEntry();
     }

--- a/src/Node/EmbeddedEntryBlock.php
+++ b/src/Node/EmbeddedEntryBlock.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 
@@ -25,7 +25,6 @@ class EmbeddedEntryBlock extends BlockNode
      * EmbeddedEntryBlock constructor.
      *
      * @param NodeInterface[] $content
-     * @param EntryReferenceInterface $reference
      */
     public function __construct(array $content, EntryReferenceInterface $reference)
     {

--- a/src/Node/EmbeddedEntryBlock.php
+++ b/src/Node/EmbeddedEntryBlock.php
@@ -12,28 +12,30 @@ declare(strict_types=1);
 namespace Contentful\RichText\Node;
 
 use Contentful\Core\Resource\EntryInterface;
+use Contentful\RichText\NodeMapper\Reference\EntryReferenceInterface;
 
 class EmbeddedEntryBlock extends BlockNode
 {
     /**
-     * @var EntryInterface
+     * @var EntryReferenceInterface
      */
-    protected $entry;
+    protected $reference;
 
     /**
      * EmbeddedEntryBlock constructor.
      *
      * @param NodeInterface[] $content
+     * @param EntryReferenceInterface $reference
      */
-    public function __construct(array $content, EntryInterface $entry)
+    public function __construct(array $content, EntryReferenceInterface $reference)
     {
         parent::__construct($content);
-        $this->entry = $entry;
+        $this->reference = $reference;
     }
 
     public function getEntry(): EntryInterface
     {
-        return $this->entry;
+        return $this->reference->getEntry();
     }
 
     /**
@@ -52,7 +54,7 @@ class EmbeddedEntryBlock extends BlockNode
         return [
             'nodeType' => self::getType(),
             'data' => [
-                'target' => $this->entry->asLink(),
+                'target' => $this->reference,
             ],
             'content' => $this->content,
         ];

--- a/src/Node/EmbeddedEntryInline.php
+++ b/src/Node/EmbeddedEntryInline.php
@@ -12,28 +12,31 @@ declare(strict_types=1);
 namespace Contentful\RichText\Node;
 
 use Contentful\Core\Resource\EntryInterface;
+use Contentful\RichText\NodeMapper\Reference\EntryReferenceInterface;
 
 class EmbeddedEntryInline extends InlineNode
 {
+
     /**
-     * @var EntryInterface
+     * @var EntryReferenceInterface
      */
-    protected $entry;
+    protected $reference;
 
     /**
      * EmbeddedEntryInline constructor.
      *
      * @param NodeInterface[] $content
+     * @param EntryReferenceInterface $reference
      */
-    public function __construct(array $content, EntryInterface $entry)
+    public function __construct(array $content, EntryReferenceInterface $reference)
     {
         parent::__construct($content);
-        $this->entry = $entry;
+        $this->reference = $reference;
     }
 
     public function getEntry(): EntryInterface
     {
-        return $this->entry;
+        return $this->reference->getEntry();
     }
 
     /**
@@ -52,7 +55,7 @@ class EmbeddedEntryInline extends InlineNode
         return [
             'nodeType' => self::getType(),
             'data' => [
-                'target' => $this->entry->asLink(),
+                'target' => $this->reference,
             ],
             'content' => $this->content,
         ];

--- a/src/Node/EmbeddedEntryInline.php
+++ b/src/Node/EmbeddedEntryInline.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Contentful\RichText\Node;
 
-use Contentful\Core\Resource\EntryInterface;
+use Contentful\Core\Resource\ResourceInterface;
 use Contentful\RichText\NodeMapper\Reference\EntryReferenceInterface;
 
 class EmbeddedEntryInline extends InlineNode
@@ -32,7 +32,7 @@ class EmbeddedEntryInline extends InlineNode
         $this->reference = $reference;
     }
 
-    public function getEntry(): EntryInterface
+    public function getEntry(): ResourceInterface
     {
         return $this->reference->getEntry();
     }

--- a/src/Node/EmbeddedEntryInline.php
+++ b/src/Node/EmbeddedEntryInline.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Contentful\RichText\Node;
 
-use Contentful\Core\Resource\ResourceInterface;
+use Contentful\Core\Resource\EntryInterface;
 use Contentful\RichText\NodeMapper\Reference\EntryReferenceInterface;
 
 class EmbeddedEntryInline extends InlineNode
@@ -32,7 +32,7 @@ class EmbeddedEntryInline extends InlineNode
         $this->reference = $reference;
     }
 
-    public function getEntry(): ResourceInterface
+    public function getEntry(): EntryInterface
     {
         return $this->reference->getEntry();
     }

--- a/src/Node/EmbeddedEntryInline.php
+++ b/src/Node/EmbeddedEntryInline.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 
@@ -16,7 +16,6 @@ use Contentful\RichText\NodeMapper\Reference\EntryReferenceInterface;
 
 class EmbeddedEntryInline extends InlineNode
 {
-
     /**
      * @var EntryReferenceInterface
      */
@@ -26,7 +25,6 @@ class EmbeddedEntryInline extends InlineNode
      * EmbeddedEntryInline constructor.
      *
      * @param NodeInterface[] $content
-     * @param EntryReferenceInterface $reference
      */
     public function __construct(array $content, EntryReferenceInterface $reference)
     {

--- a/src/Node/EntryHyperlink.php
+++ b/src/Node/EntryHyperlink.php
@@ -11,9 +11,8 @@ declare(strict_types=1);
 
 namespace Contentful\RichText\Node;
 
-use Contentful\Core\Api\Link;
-use Contentful\Core\Api\LinkResolverInterface;
 use Contentful\Core\Resource\EntryInterface;
+use Contentful\RichText\NodeMapper\Reference\EntryReferenceInterface;
 
 class EntryHyperlink extends InlineNode
 {
@@ -23,35 +22,22 @@ class EntryHyperlink extends InlineNode
     protected $title;
 
     /**
-     * @var EntryInterface
+     * @var EntryReferenceInterface
      */
-    protected $entry;
-
-    /**
-     * @var \Contentful\Core\Api\Link
-     */
-    private $link;
-
-    /**
-     * @var \Contentful\Core\Api\LinkResolverInterface
-     */
-    private $linkResolver;
+    protected $reference;
 
     /**
      * AssetHyperlink constructor.
      *
      * @param NodeInterface[] $content
      * @param string $title
-     * @param \Contentful\Core\Api\Link $link
-     * @param \Contentful\Core\Api\LinkResolverInterface $linkResolver
+     * @param EntryReferenceInterface $reference
      */
-    public function __construct(array $content, string $title, Link $link, LinkResolverInterface $linkResolver)
+    public function __construct(array $content, string $title, EntryReferenceInterface $reference)
     {
         parent::__construct($content);
         $this->title = $title;
-        $this->entry = null;
-        $this->link = $link;
-        $this->linkResolver = $linkResolver;
+        $this->reference = $reference;
     }
 
     /**
@@ -59,10 +45,7 @@ class EntryHyperlink extends InlineNode
      */
     public function getEntry(): EntryInterface
     {
-        if (is_null($this->entry)) {
-            $this->entry = $this->linkResolver->resolveLink($this->link);
-        }
-        return $this->entry;
+        return $this->reference->getEntry();
     }
 
     public function getTitle(): string
@@ -87,7 +70,7 @@ class EntryHyperlink extends InlineNode
             'nodeType' => self::getType(),
             'data' => [
                 'title' => $this->title,
-                'target' => $this->link,
+                'target' => $this->reference,
             ],
             'content' => $this->content,
         ];

--- a/src/Node/EntryHyperlink.php
+++ b/src/Node/EntryHyperlink.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 
@@ -30,8 +30,6 @@ class EntryHyperlink extends InlineNode
      * AssetHyperlink constructor.
      *
      * @param NodeInterface[] $content
-     * @param string $title
-     * @param EntryReferenceInterface $reference
      */
     public function __construct(array $content, string $title, EntryReferenceInterface $reference)
     {
@@ -40,9 +38,6 @@ class EntryHyperlink extends InlineNode
         $this->reference = $reference;
     }
 
-    /**
-     * @return EntryInterface
-     */
     public function getEntry(): EntryInterface
     {
         return $this->reference->getEntry();

--- a/src/Node/EntryHyperlink.php
+++ b/src/Node/EntryHyperlink.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Contentful\RichText\Node;
 
+use Contentful\Core\Api\Link;
+use Contentful\Core\Api\LinkResolverInterface;
 use Contentful\Core\Resource\EntryInterface;
 
 class EntryHyperlink extends InlineNode
@@ -26,19 +28,40 @@ class EntryHyperlink extends InlineNode
     protected $entry;
 
     /**
+     * @var \Contentful\Core\Api\Link
+     */
+    private $link;
+
+    /**
+     * @var \Contentful\Core\Api\LinkResolverInterface
+     */
+    private $linkResolver;
+
+    /**
      * AssetHyperlink constructor.
      *
      * @param NodeInterface[] $content
+     * @param string $title
+     * @param \Contentful\Core\Api\Link $link
+     * @param \Contentful\Core\Api\LinkResolverInterface $linkResolver
      */
-    public function __construct(array $content, EntryInterface $entry, string $title)
+    public function __construct(array $content, string $title, Link $link, LinkResolverInterface $linkResolver)
     {
         parent::__construct($content);
-        $this->entry = $entry;
         $this->title = $title;
+        $this->entry = null;
+        $this->link = $link;
+        $this->linkResolver = $linkResolver;
     }
 
+    /**
+     * @return EntryInterface
+     */
     public function getEntry(): EntryInterface
     {
+        if (is_null($this->entry)) {
+            $this->entry = $this->linkResolver->resolveLink($this->link);
+        }
         return $this->entry;
     }
 
@@ -64,7 +87,7 @@ class EntryHyperlink extends InlineNode
             'nodeType' => self::getType(),
             'data' => [
                 'title' => $this->title,
-                'target' => $this->entry->asLink(),
+                'target' => $this->link,
             ],
             'content' => $this->content,
         ];

--- a/src/Node/EntryHyperlink.php
+++ b/src/Node/EntryHyperlink.php
@@ -31,7 +31,7 @@ class EntryHyperlink extends InlineNode
      *
      * @param NodeInterface[] $content
      */
-    public function __construct(array $content, string $title, EntryReferenceInterface $reference)
+    public function __construct(array $content, EntryReferenceInterface $reference, string $title)
     {
         parent::__construct($content);
         $this->title = $title;

--- a/src/Node/EntryHyperlink.php
+++ b/src/Node/EntryHyperlink.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Contentful\RichText\Node;
 
-use Contentful\Core\Resource\EntryInterface;
+use Contentful\Core\Resource\ResourceInterface;
 use Contentful\RichText\NodeMapper\Reference\EntryReferenceInterface;
 
 class EntryHyperlink extends InlineNode
@@ -38,7 +38,7 @@ class EntryHyperlink extends InlineNode
         $this->reference = $reference;
     }
 
-    public function getEntry(): EntryInterface
+    public function getEntry(): ResourceInterface
     {
         return $this->reference->getEntry();
     }

--- a/src/Node/EntryHyperlink.php
+++ b/src/Node/EntryHyperlink.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Contentful\RichText\Node;
 
-use Contentful\Core\Resource\ResourceInterface;
+use Contentful\Core\Resource\EntryInterface;
 use Contentful\RichText\NodeMapper\Reference\EntryReferenceInterface;
 
 class EntryHyperlink extends InlineNode
@@ -38,7 +38,7 @@ class EntryHyperlink extends InlineNode
         $this->reference = $reference;
     }
 
-    public function getEntry(): ResourceInterface
+    public function getEntry(): EntryInterface
     {
         return $this->reference->getEntry();
     }

--- a/src/Node/Heading1.php
+++ b/src/Node/Heading1.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/Heading2.php
+++ b/src/Node/Heading2.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/Heading3.php
+++ b/src/Node/Heading3.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/Heading4.php
+++ b/src/Node/Heading4.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/Heading5.php
+++ b/src/Node/Heading5.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/Heading6.php
+++ b/src/Node/Heading6.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/Hr.php
+++ b/src/Node/Hr.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/Hyperlink.php
+++ b/src/Node/Hyperlink.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/InlineNode.php
+++ b/src/Node/InlineNode.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/ListItem.php
+++ b/src/Node/ListItem.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/NodeInterface.php
+++ b/src/Node/NodeInterface.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/Nothing.php
+++ b/src/Node/Nothing.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/OrderedList.php
+++ b/src/Node/OrderedList.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/Paragraph.php
+++ b/src/Node/Paragraph.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/Text.php
+++ b/src/Node/Text.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Node/UnorderedList.php
+++ b/src/Node/UnorderedList.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/AssetHyperlink.php
+++ b/src/NodeMapper/AssetHyperlink.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/Blockquote.php
+++ b/src/NodeMapper/Blockquote.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/Document.php
+++ b/src/NodeMapper/Document.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/EmbeddedAssetBlock.php
+++ b/src/NodeMapper/EmbeddedAssetBlock.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/EmbeddedAssetInline.php
+++ b/src/NodeMapper/EmbeddedAssetInline.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/EmbeddedEntryBlock.php
+++ b/src/NodeMapper/EmbeddedEntryBlock.php
@@ -13,10 +13,9 @@ namespace Contentful\RichText\NodeMapper;
 
 use Contentful\Core\Api\Link;
 use Contentful\Core\Api\LinkResolverInterface;
-use Contentful\Core\Resource\EntryInterface;
-use Contentful\RichText\Exception\MapperException;
 use Contentful\RichText\Node\EmbeddedEntryBlock as NodeClass;
 use Contentful\RichText\Node\NodeInterface;
+use Contentful\RichText\NodeMapper\Reference\EntryReference;
 use Contentful\RichText\ParserInterface;
 
 class EmbeddedEntryBlock implements NodeMapperInterface
@@ -28,18 +27,12 @@ class EmbeddedEntryBlock implements NodeMapperInterface
     {
         $linkData = $data['data']['target']['sys'];
 
-        try {
-            /** @var EntryInterface $entry */
-            $entry = $linkResolver->resolveLink(
-                new Link($linkData['id'], $linkData['linkType'])
-            );
-        } catch (\Throwable $exception) {
-            throw new MapperException($data);
-        }
-
         return new NodeClass(
             $parser->parseCollection($data['content']),
-            $entry
+            new EntryReference(
+                new Link($linkData['id'], $linkData['linkType']),
+                $linkResolver
+            )
         );
     }
 }

--- a/src/NodeMapper/EmbeddedEntryBlock.php
+++ b/src/NodeMapper/EmbeddedEntryBlock.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/EmbeddedEntryInline.php
+++ b/src/NodeMapper/EmbeddedEntryInline.php
@@ -13,10 +13,9 @@ namespace Contentful\RichText\NodeMapper;
 
 use Contentful\Core\Api\Link;
 use Contentful\Core\Api\LinkResolverInterface;
-use Contentful\Core\Resource\EntryInterface;
-use Contentful\RichText\Exception\MapperException;
 use Contentful\RichText\Node\EmbeddedEntryInline as NodeClass;
 use Contentful\RichText\Node\NodeInterface;
+use Contentful\RichText\NodeMapper\Reference\EntryReference;
 use Contentful\RichText\ParserInterface;
 
 class EmbeddedEntryInline implements NodeMapperInterface
@@ -28,18 +27,12 @@ class EmbeddedEntryInline implements NodeMapperInterface
     {
         $linkData = $data['data']['target']['sys'];
 
-        try {
-            /** @var EntryInterface $entry */
-            $entry = $linkResolver->resolveLink(
-                new Link($linkData['id'], $linkData['linkType'])
-            );
-        } catch (\Throwable $exception) {
-            throw new MapperException($data);
-        }
-
         return new NodeClass(
             $parser->parseCollection($data['content']),
-            $entry
+            new EntryReference(
+                new Link($linkData['id'], $linkData['linkType']),
+                $linkResolver
+            )
         );
     }
 }

--- a/src/NodeMapper/EmbeddedEntryInline.php
+++ b/src/NodeMapper/EmbeddedEntryInline.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/EntryHyperlink.php
+++ b/src/NodeMapper/EntryHyperlink.php
@@ -13,8 +13,6 @@ namespace Contentful\RichText\NodeMapper;
 
 use Contentful\Core\Api\Link;
 use Contentful\Core\Api\LinkResolverInterface;
-use Contentful\Core\Resource\EntryInterface;
-use Contentful\RichText\Exception\MapperException;
 use Contentful\RichText\Node\EntryHyperlink as NodeClass;
 use Contentful\RichText\Node\NodeInterface;
 use Contentful\RichText\ParserInterface;
@@ -28,19 +26,11 @@ class EntryHyperlink implements NodeMapperInterface
     {
         $linkData = $data['data']['target']['sys'];
 
-        try {
-            /** @var EntryInterface $entry */
-            $entry = $linkResolver->resolveLink(
-                new Link($linkData['id'], $linkData['linkType'])
-            );
-        } catch (\Throwable $exception) {
-            throw new MapperException($data);
-        }
-
         return new NodeClass(
             $parser->parseCollection($data['content']),
-            $entry,
-            $data['data']['title'] ?? ''
+            $data['data']['title'] ?? '',
+            new Link($linkData['id'], $linkData['linkType']),
+            $linkResolver
         );
     }
 }

--- a/src/NodeMapper/EntryHyperlink.php
+++ b/src/NodeMapper/EntryHyperlink.php
@@ -29,11 +29,11 @@ class EntryHyperlink implements NodeMapperInterface
 
         return new NodeClass(
             $parser->parseCollection($data['content']),
-            $data['data']['title'] ?? '',
             new EntryReference(
                 new Link($linkData['id'], $linkData['linkType']),
                 $linkResolver
-            )
+            ),
+            $data['data']['title'] ?? ''
         );
     }
 }

--- a/src/NodeMapper/EntryHyperlink.php
+++ b/src/NodeMapper/EntryHyperlink.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/EntryHyperlink.php
+++ b/src/NodeMapper/EntryHyperlink.php
@@ -15,6 +15,7 @@ use Contentful\Core\Api\Link;
 use Contentful\Core\Api\LinkResolverInterface;
 use Contentful\RichText\Node\EntryHyperlink as NodeClass;
 use Contentful\RichText\Node\NodeInterface;
+use Contentful\RichText\NodeMapper\Reference\EntryReference;
 use Contentful\RichText\ParserInterface;
 
 class EntryHyperlink implements NodeMapperInterface
@@ -29,8 +30,10 @@ class EntryHyperlink implements NodeMapperInterface
         return new NodeClass(
             $parser->parseCollection($data['content']),
             $data['data']['title'] ?? '',
-            new Link($linkData['id'], $linkData['linkType']),
-            $linkResolver
+            new EntryReference(
+                new Link($linkData['id'], $linkData['linkType']),
+                $linkResolver
+            )
         );
     }
 }

--- a/src/NodeMapper/Heading1.php
+++ b/src/NodeMapper/Heading1.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/Heading2.php
+++ b/src/NodeMapper/Heading2.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/Heading3.php
+++ b/src/NodeMapper/Heading3.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/Heading4.php
+++ b/src/NodeMapper/Heading4.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/Heading5.php
+++ b/src/NodeMapper/Heading5.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/Heading6.php
+++ b/src/NodeMapper/Heading6.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/Hr.php
+++ b/src/NodeMapper/Hr.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/Hyperlink.php
+++ b/src/NodeMapper/Hyperlink.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/ListItem.php
+++ b/src/NodeMapper/ListItem.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/NodeMapperInterface.php
+++ b/src/NodeMapper/NodeMapperInterface.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/Nothing.php
+++ b/src/NodeMapper/Nothing.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/OrderedList.php
+++ b/src/NodeMapper/OrderedList.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/Paragraph.php
+++ b/src/NodeMapper/Paragraph.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/Reference/EntryReference.php
+++ b/src/NodeMapper/Reference/EntryReference.php
@@ -13,7 +13,7 @@ namespace Contentful\RichText\NodeMapper\Reference;
 
 use Contentful\Core\Api\Link;
 use Contentful\Core\Api\LinkResolverInterface;
-use Contentful\Core\Resource\ResourceInterface;
+use Contentful\Core\Resource\EntryInterface;
 use InvalidArgumentException;
 
 class EntryReference implements EntryReferenceInterface
@@ -29,7 +29,7 @@ class EntryReference implements EntryReferenceInterface
     private $linkResolver;
 
     /**
-     * @var ResourceInterface|null
+     * @var EntryInterface
      */
     private $entry;
 
@@ -52,7 +52,7 @@ class EntryReference implements EntryReferenceInterface
         return $this->link;
     }
 
-    public function getEntry(): ResourceInterface
+    public function getEntry(): EntryInterface
     {
         if (null === $this->entry) {
             $this->entry = $this->linkResolver->resolveLink($this->link);

--- a/src/NodeMapper/Reference/EntryReference.php
+++ b/src/NodeMapper/Reference/EntryReference.php
@@ -13,7 +13,7 @@ namespace Contentful\RichText\NodeMapper\Reference;
 
 use Contentful\Core\Api\Link;
 use Contentful\Core\Api\LinkResolverInterface;
-use Contentful\Core\Resource\EntryInterface;
+use Contentful\Core\Resource\ResourceInterface;
 use InvalidArgumentException;
 
 class EntryReference implements EntryReferenceInterface
@@ -29,7 +29,7 @@ class EntryReference implements EntryReferenceInterface
     private $linkResolver;
 
     /**
-     * @var EntryInterface
+     * @var ResourceInterface|null
      */
     private $entry;
 
@@ -52,7 +52,7 @@ class EntryReference implements EntryReferenceInterface
         return $this->link;
     }
 
-    public function getEntry(): EntryInterface
+    public function getEntry(): ResourceInterface
     {
         if (null === $this->entry) {
             $this->entry = $this->linkResolver->resolveLink($this->link);

--- a/src/NodeMapper/Reference/EntryReference.php
+++ b/src/NodeMapper/Reference/EntryReference.php
@@ -29,7 +29,7 @@ class EntryReference implements EntryReferenceInterface
     private $linkResolver;
 
     /**
-     * @var EntryInterface
+     * @var EntryInterface|null
      */
     private $entry;
 
@@ -55,7 +55,15 @@ class EntryReference implements EntryReferenceInterface
     public function getEntry(): EntryInterface
     {
         if (null === $this->entry) {
-            $this->entry = $this->linkResolver->resolveLink($this->link);
+            $resource = $this->linkResolver->resolveLink($this->link);
+
+            if ($resource instanceof EntryInterface) {
+                return $this->entry = $resource;
+            }
+
+            // @codeCoverageIgnoreStart
+            throw new \RuntimeException(\sprintf('A link has been resolved to an instance of %s, but %s is expected. This should never happen.', \get_class($resource), EntryInterface::class));
+            // @codeCoverageIgnoreEnd
         }
 
         return $this->entry;

--- a/src/NodeMapper/Reference/EntryReference.php
+++ b/src/NodeMapper/Reference/EntryReference.php
@@ -1,0 +1,60 @@
+<?php
+namespace Contentful\RichText\NodeMapper\Reference;
+
+use Contentful\Core\Api\Link;
+use Contentful\Core\Api\LinkResolverInterface;
+use Contentful\Core\Resource\EntryInterface;
+use InvalidArgumentException;
+
+class EntryReference implements EntryReferenceInterface
+{
+    /**
+     * @var Link
+     */
+    private $link;
+
+    /**
+     * @var LinkResolverInterface
+     */
+    private $linkResolver;
+
+    /**
+     * @var EntryInterface
+     */
+    private $entry;
+
+    /**
+     * EntryReference constructor.
+     *
+     * @param Link $link
+     * @param LinkResolverInterface $linkResolver
+     */
+    public function __construct(Link $link, LinkResolverInterface $linkResolver)
+    {
+        if ($link->getLinkType() !== 'Entry') {
+            throw new InvalidArgumentException('Link is required to reference an Entry.');
+        }
+
+        $this->entry = null;
+        $this->link = $link;
+        $this->linkResolver = $linkResolver;
+    }
+
+    public function getLink(): Link
+    {
+        return $this->link;
+    }
+
+    public function getEntry(): EntryInterface
+    {
+        if (is_null($this->entry)) {
+            $this->entry = $this->linkResolver->resolveLink($this->link);
+        }
+        return $this->entry;
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->link->jsonSerialize();
+    }
+}

--- a/src/NodeMapper/Reference/EntryReference.php
+++ b/src/NodeMapper/Reference/EntryReference.php
@@ -1,4 +1,14 @@
 <?php
+
+/**
+ * This file is part of the contentful/rich-text package.
+ *
+ * @copyright 2015-2020 Contentful GmbH
+ * @license   MIT
+ */
+
+declare(strict_types=1);
+
 namespace Contentful\RichText\NodeMapper\Reference;
 
 use Contentful\Core\Api\Link;
@@ -25,13 +35,10 @@ class EntryReference implements EntryReferenceInterface
 
     /**
      * EntryReference constructor.
-     *
-     * @param Link $link
-     * @param LinkResolverInterface $linkResolver
      */
     public function __construct(Link $link, LinkResolverInterface $linkResolver)
     {
-        if ($link->getLinkType() !== 'Entry') {
+        if ('Entry' !== $link->getLinkType()) {
             throw new InvalidArgumentException('Link is required to reference an Entry.');
         }
 
@@ -47,9 +54,10 @@ class EntryReference implements EntryReferenceInterface
 
     public function getEntry(): EntryInterface
     {
-        if (is_null($this->entry)) {
+        if (null === $this->entry) {
             $this->entry = $this->linkResolver->resolveLink($this->link);
         }
+
         return $this->entry;
     }
 

--- a/src/NodeMapper/Reference/EntryReferenceInterface.php
+++ b/src/NodeMapper/Reference/EntryReferenceInterface.php
@@ -1,4 +1,14 @@
 <?php
+
+/**
+ * This file is part of the contentful/rich-text package.
+ *
+ * @copyright 2015-2020 Contentful GmbH
+ * @license   MIT
+ */
+
+declare(strict_types=1);
+
 namespace Contentful\RichText\NodeMapper\Reference;
 
 use Contentful\Core\Resource\EntryInterface;

--- a/src/NodeMapper/Reference/EntryReferenceInterface.php
+++ b/src/NodeMapper/Reference/EntryReferenceInterface.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace Contentful\RichText\NodeMapper\Reference;
 
-use Contentful\Core\Resource\EntryInterface;
+use Contentful\Core\Resource\ResourceInterface;
 use JsonSerializable;
 
 interface EntryReferenceInterface extends JsonSerializable
 {
-    public function getEntry(): EntryInterface;
+    public function getEntry(): ResourceInterface;
 }

--- a/src/NodeMapper/Reference/EntryReferenceInterface.php
+++ b/src/NodeMapper/Reference/EntryReferenceInterface.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace Contentful\RichText\NodeMapper\Reference;
 
-use Contentful\Core\Resource\ResourceInterface;
+use Contentful\Core\Resource\EntryInterface;
 use JsonSerializable;
 
 interface EntryReferenceInterface extends JsonSerializable
 {
-    public function getEntry(): ResourceInterface;
+    public function getEntry(): EntryInterface;
 }

--- a/src/NodeMapper/Reference/EntryReferenceInterface.php
+++ b/src/NodeMapper/Reference/EntryReferenceInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace Contentful\RichText\NodeMapper\Reference;
+
+use Contentful\Core\Resource\EntryInterface;
+use JsonSerializable;
+
+interface EntryReferenceInterface extends JsonSerializable
+{
+    public function getEntry(): EntryInterface;
+}

--- a/src/NodeMapper/Reference/StaticEntryReference.php
+++ b/src/NodeMapper/Reference/StaticEntryReference.php
@@ -1,0 +1,36 @@
+<?php
+namespace Contentful\RichText\NodeMapper\Reference;
+
+use Contentful\Core\Api\Link;
+use Contentful\Core\Resource\EntryInterface;
+
+class StaticEntryReference implements EntryReferenceInterface
+{
+    /** @var EntryInterface */
+    private $entry;
+
+    /**
+     * StaticEntryReference constructor.
+     *
+     * @param EntryInterface $entry
+     */
+    public function __construct(EntryInterface $entry)
+    {
+        $this->entry = $entry;
+    }
+
+    public function getLink(): Link
+    {
+        return $this->entry->asLink();
+    }
+
+    public function getEntry(): EntryInterface
+    {
+        return $this->entry;
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->entry->asLink()->jsonSerialize();
+    }
+}

--- a/src/NodeMapper/Reference/StaticEntryReference.php
+++ b/src/NodeMapper/Reference/StaticEntryReference.php
@@ -1,4 +1,14 @@
 <?php
+
+/**
+ * This file is part of the contentful/rich-text package.
+ *
+ * @copyright 2015-2020 Contentful GmbH
+ * @license   MIT
+ */
+
+declare(strict_types=1);
+
 namespace Contentful\RichText\NodeMapper\Reference;
 
 use Contentful\Core\Api\Link;
@@ -11,8 +21,6 @@ class StaticEntryReference implements EntryReferenceInterface
 
     /**
      * StaticEntryReference constructor.
-     *
-     * @param EntryInterface $entry
      */
     public function __construct(EntryInterface $entry)
     {

--- a/src/NodeMapper/Reference/StaticEntryReference.php
+++ b/src/NodeMapper/Reference/StaticEntryReference.php
@@ -13,7 +13,6 @@ namespace Contentful\RichText\NodeMapper\Reference;
 
 use Contentful\Core\Api\Link;
 use Contentful\Core\Resource\EntryInterface;
-use Contentful\Core\Resource\ResourceInterface;
 
 class StaticEntryReference implements EntryReferenceInterface
 {
@@ -33,7 +32,7 @@ class StaticEntryReference implements EntryReferenceInterface
         return $this->entry->asLink();
     }
 
-    public function getEntry(): ResourceInterface
+    public function getEntry(): EntryInterface
     {
         return $this->entry;
     }

--- a/src/NodeMapper/Reference/StaticEntryReference.php
+++ b/src/NodeMapper/Reference/StaticEntryReference.php
@@ -13,6 +13,7 @@ namespace Contentful\RichText\NodeMapper\Reference;
 
 use Contentful\Core\Api\Link;
 use Contentful\Core\Resource\EntryInterface;
+use Contentful\Core\Resource\ResourceInterface;
 
 class StaticEntryReference implements EntryReferenceInterface
 {
@@ -32,7 +33,7 @@ class StaticEntryReference implements EntryReferenceInterface
         return $this->entry->asLink();
     }
 
-    public function getEntry(): EntryInterface
+    public function getEntry(): ResourceInterface
     {
         return $this->entry;
     }

--- a/src/NodeMapper/Text.php
+++ b/src/NodeMapper/Text.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeMapper/UnorderedList.php
+++ b/src/NodeMapper/UnorderedList.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/AssetHyperlink.php
+++ b/src/NodeRenderer/AssetHyperlink.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/Blockquote.php
+++ b/src/NodeRenderer/Blockquote.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/CatchAll.php
+++ b/src/NodeRenderer/CatchAll.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/Document.php
+++ b/src/NodeRenderer/Document.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/EmbeddedAssetBlock.php
+++ b/src/NodeRenderer/EmbeddedAssetBlock.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/EmbeddedAssetInline.php
+++ b/src/NodeRenderer/EmbeddedAssetInline.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/EmbeddedEntryBlock.php
+++ b/src/NodeRenderer/EmbeddedEntryBlock.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/EmbeddedEntryInline.php
+++ b/src/NodeRenderer/EmbeddedEntryInline.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/EntryHyperlink.php
+++ b/src/NodeRenderer/EntryHyperlink.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/Heading1.php
+++ b/src/NodeRenderer/Heading1.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/Heading2.php
+++ b/src/NodeRenderer/Heading2.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/Heading3.php
+++ b/src/NodeRenderer/Heading3.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/Heading4.php
+++ b/src/NodeRenderer/Heading4.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/Heading5.php
+++ b/src/NodeRenderer/Heading5.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/Heading6.php
+++ b/src/NodeRenderer/Heading6.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/Hr.php
+++ b/src/NodeRenderer/Hr.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/Hyperlink.php
+++ b/src/NodeRenderer/Hyperlink.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/ListItem.php
+++ b/src/NodeRenderer/ListItem.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/NodeRendererInterface.php
+++ b/src/NodeRenderer/NodeRendererInterface.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/Nothing.php
+++ b/src/NodeRenderer/Nothing.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/OrderedList.php
+++ b/src/NodeRenderer/OrderedList.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/Paragraph.php
+++ b/src/NodeRenderer/Paragraph.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/Text.php
+++ b/src/NodeRenderer/Text.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/NodeRenderer/UnorderedList.php
+++ b/src/NodeRenderer/UnorderedList.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/ParserInterface.php
+++ b/src/ParserInterface.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/src/RendererInterface.php
+++ b/src/RendererInterface.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Fixtures/Unit/Parser/embedded-invalid-link-type.json
+++ b/tests/Fixtures/Unit/Parser/embedded-invalid-link-type.json
@@ -1,0 +1,13 @@
+{
+  "nodeType": "embedded-entry-inline",
+  "data": {
+    "target": {
+      "sys": {
+        "type": "Link",
+        "id": "resourceId",
+        "linkType": "Asset"
+      }
+    }
+  },
+  "content": []
+}

--- a/tests/Implementation/Asset.php
+++ b/tests/Implementation/Asset.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Implementation/Entry.php
+++ b/tests/Implementation/Entry.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Implementation/FailingLinkResolver.php
+++ b/tests/Implementation/FailingLinkResolver.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Implementation/LinkResolver.php
+++ b/tests/Implementation/LinkResolver.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Implementation/Mark.php
+++ b/tests/Implementation/Mark.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Implementation/Node.php
+++ b/tests/Implementation/Node.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Implementation/NodeMapper.php
+++ b/tests/Implementation/NodeMapper.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Implementation/NodeRenderer.php
+++ b/tests/Implementation/NodeRenderer.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Implementation/PlatesNodeRenderer.php
+++ b/tests/Implementation/PlatesNodeRenderer.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Implementation/Renderer.php
+++ b/tests/Implementation/Renderer.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Implementation/Resource.php
+++ b/tests/Implementation/Resource.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Implementation/SystemProperties.php
+++ b/tests/Implementation/SystemProperties.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Implementation/TwigNodeRenderer.php
+++ b/tests/Implementation/TwigNodeRenderer.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Integration/AllNodesHaveParserTest.php
+++ b/tests/Integration/AllNodesHaveParserTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Integration/AllNodesHaveRendererTest.php
+++ b/tests/Integration/AllNodesHaveRendererTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Integration/FallbackNodeRendererTest.php
+++ b/tests/Integration/FallbackNodeRendererTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Integration/NoBlockNodeChildOfInlineTest.php
+++ b/tests/Integration/NoBlockNodeChildOfInlineTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Integration/PlatesNodeRendererTest.php
+++ b/tests/Integration/PlatesNodeRendererTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Integration/TwigNodeRendererTest.php
+++ b/tests/Integration/TwigNodeRendererTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Bridge/PlatesExtensionTest.php
+++ b/tests/Unit/Bridge/PlatesExtensionTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Bridge/TwigExtensionTest.php
+++ b/tests/Unit/Bridge/TwigExtensionTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Mark/BoldTest.php
+++ b/tests/Unit/Mark/BoldTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Mark/CodeTest.php
+++ b/tests/Unit/Mark/CodeTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Mark/ItalicTest.php
+++ b/tests/Unit/Mark/ItalicTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Mark/UnderlineTest.php
+++ b/tests/Unit/Mark/UnderlineTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/AssetHyperlinkTest.php
+++ b/tests/Unit/Node/AssetHyperlinkTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/BlockquoteTest.php
+++ b/tests/Unit/Node/BlockquoteTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/DocumentTest.php
+++ b/tests/Unit/Node/DocumentTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/EmbeddedAssetBlockTest.php
+++ b/tests/Unit/Node/EmbeddedAssetBlockTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/EmbeddedAssetInlineTest.php
+++ b/tests/Unit/Node/EmbeddedAssetInlineTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/EmbeddedEntryBlockTest.php
+++ b/tests/Unit/Node/EmbeddedEntryBlockTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Contentful\Tests\RichText\Unit\Node;
 
+use Contentful\Core\Api\Link;
 use Contentful\RichText\Node\EmbeddedEntryBlock;
 use Contentful\RichText\NodeMapper\Reference\StaticEntryReference;
 use Contentful\Tests\RichText\Implementation\Entry;
@@ -24,7 +25,10 @@ class EmbeddedEntryBlockTest extends TestCase
 
         $nodes = $this->createNodes(5);
         $entry = new Entry('entryId');
-        $node = new EmbeddedEntryBlock($nodes, new StaticEntryReference($entry));
+        $staticEntry = new StaticEntryReference($entry);
+        $this->assertInstanceOf(Link::class, $staticEntry->getLink());
+
+        $node = new EmbeddedEntryBlock($nodes, $staticEntry);
 
         $this->assertSame($nodes, $node->getContent());
         $this->assertSame($entry, $node->getEntry());

--- a/tests/Unit/Node/EmbeddedEntryBlockTest.php
+++ b/tests/Unit/Node/EmbeddedEntryBlockTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Contentful\Tests\RichText\Unit\Node;
 
 use Contentful\RichText\Node\EmbeddedEntryBlock;
+use Contentful\RichText\NodeMapper\Reference\StaticEntryReference;
 use Contentful\Tests\RichText\Implementation\Entry;
 use Contentful\Tests\RichText\TestCase;
 
@@ -23,7 +24,7 @@ class EmbeddedEntryBlockTest extends TestCase
 
         $nodes = $this->createNodes(5);
         $entry = new Entry('entryId');
-        $node = new EmbeddedEntryBlock($nodes, $entry);
+        $node = new EmbeddedEntryBlock($nodes, new StaticEntryReference($entry));
 
         $this->assertSame($nodes, $node->getContent());
         $this->assertSame($entry, $node->getEntry());

--- a/tests/Unit/Node/EmbeddedEntryBlockTest.php
+++ b/tests/Unit/Node/EmbeddedEntryBlockTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/EmbeddedEntryInlineTest.php
+++ b/tests/Unit/Node/EmbeddedEntryInlineTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Contentful\Tests\RichText\Unit\Node;
 
 use Contentful\RichText\Node\EmbeddedEntryInline;
+use Contentful\RichText\NodeMapper\Reference\StaticEntryReference;
 use Contentful\Tests\RichText\Implementation\Entry;
 use Contentful\Tests\RichText\TestCase;
 
@@ -23,7 +24,7 @@ class EmbeddedEntryInlineTest extends TestCase
 
         $nodes = $this->createNodes(5);
         $entry = new Entry('entryId');
-        $node = new EmbeddedEntryInline($nodes, $entry);
+        $node = new EmbeddedEntryInline($nodes, new StaticEntryReference($entry));
 
         $this->assertSame($nodes, $node->getContent());
         $this->assertSame($entry, $node->getEntry());

--- a/tests/Unit/Node/EmbeddedEntryInlineTest.php
+++ b/tests/Unit/Node/EmbeddedEntryInlineTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/EntryHyperlinkTest.php
+++ b/tests/Unit/Node/EntryHyperlinkTest.php
@@ -24,7 +24,7 @@ class EntryHyperlinkTest extends TestCase
 
         $nodes = $this->createNodes(1);
         $entry = new Entry('entryId');
-        $node = new EntryHyperlink($nodes, 'Entry link', new StaticEntryReference($entry));
+        $node = new EntryHyperlink($nodes, new StaticEntryReference($entry), 'Entry link');
 
         $this->assertSame($nodes, $node->getContent());
         $this->assertSame($entry, $node->getEntry());

--- a/tests/Unit/Node/EntryHyperlinkTest.php
+++ b/tests/Unit/Node/EntryHyperlinkTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Contentful\Tests\RichText\Unit\Node;
 
 use Contentful\RichText\Node\EntryHyperlink;
+use Contentful\RichText\NodeMapper\Reference\StaticEntryReference;
 use Contentful\Tests\RichText\Implementation\Entry;
 use Contentful\Tests\RichText\TestCase;
 
@@ -23,7 +24,7 @@ class EntryHyperlinkTest extends TestCase
 
         $nodes = $this->createNodes(1);
         $entry = new Entry('entryId');
-        $node = new EntryHyperlink($nodes, $entry, 'Entry link');
+        $node = new EntryHyperlink($nodes, 'Entry link', new StaticEntryReference($entry));
 
         $this->assertSame($nodes, $node->getContent());
         $this->assertSame($entry, $node->getEntry());

--- a/tests/Unit/Node/EntryHyperlinkTest.php
+++ b/tests/Unit/Node/EntryHyperlinkTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/Heading1Test.php
+++ b/tests/Unit/Node/Heading1Test.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/Heading2Test.php
+++ b/tests/Unit/Node/Heading2Test.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/Heading3Test.php
+++ b/tests/Unit/Node/Heading3Test.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/Heading4Test.php
+++ b/tests/Unit/Node/Heading4Test.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/Heading5Test.php
+++ b/tests/Unit/Node/Heading5Test.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/Heading6Test.php
+++ b/tests/Unit/Node/Heading6Test.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/HrTest.php
+++ b/tests/Unit/Node/HrTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/HyperlinkTest.php
+++ b/tests/Unit/Node/HyperlinkTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/ListItemTest.php
+++ b/tests/Unit/Node/ListItemTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/NothingTest.php
+++ b/tests/Unit/Node/NothingTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/OrderedListTest.php
+++ b/tests/Unit/Node/OrderedListTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/ParagraphTest.php
+++ b/tests/Unit/Node/ParagraphTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/TextTest.php
+++ b/tests/Unit/Node/TextTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/Node/UnorderedListTest.php
+++ b/tests/Unit/Node/UnorderedListTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/AssetHyperlinkTest.php
+++ b/tests/Unit/NodeRenderer/AssetHyperlinkTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/BlockquoteTest.php
+++ b/tests/Unit/NodeRenderer/BlockquoteTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/CatchAllTest.php
+++ b/tests/Unit/NodeRenderer/CatchAllTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/DocumentTest.php
+++ b/tests/Unit/NodeRenderer/DocumentTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/EmbeddedAssetBlockTest.php
+++ b/tests/Unit/NodeRenderer/EmbeddedAssetBlockTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/EmbeddedAssetInlineTest.php
+++ b/tests/Unit/NodeRenderer/EmbeddedAssetInlineTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/EmbeddedEntryBlockTest.php
+++ b/tests/Unit/NodeRenderer/EmbeddedEntryBlockTest.php
@@ -32,6 +32,7 @@ class EmbeddedEntryBlockTest extends TestCase
 
         $this->assertTrue($nodeRenderer->supports($node));
         $this->assertFalse($nodeRenderer->supports(new Node('Some value')));
+        $this->assertInstanceOf(Link::class, $reference->getLink());
 
         $this->assertSame('<div>Entry#entryId</div>', $nodeRenderer->render($renderer, $node));
     }

--- a/tests/Unit/NodeRenderer/EmbeddedEntryBlockTest.php
+++ b/tests/Unit/NodeRenderer/EmbeddedEntryBlockTest.php
@@ -13,6 +13,7 @@ namespace Contentful\Tests\RichText\Unit\NodeRenderer;
 
 use Contentful\Core\Api\Link;
 use Contentful\RichText\Node\EmbeddedEntryBlock as NodeClass;
+use Contentful\RichText\NodeMapper\Reference\EntryReference;
 use Contentful\RichText\NodeRenderer\EmbeddedEntryBlock;
 use Contentful\Tests\RichText\Implementation\LinkResolver;
 use Contentful\Tests\RichText\Implementation\Node;
@@ -26,7 +27,8 @@ class EmbeddedEntryBlockTest extends TestCase
         $renderer = new Renderer();
         $nodeRenderer = new EmbeddedEntryBlock();
 
-        $node = new NodeClass([], new Link('entryId', 'Entry'), new LinkResolver());
+        $reference = new EntryReference(new Link('entryId', 'Entry'), new LinkResolver());
+        $node = new NodeClass([], $reference);
 
         $this->assertTrue($nodeRenderer->supports($node));
         $this->assertFalse($nodeRenderer->supports(new Node('Some value')));

--- a/tests/Unit/NodeRenderer/EmbeddedEntryBlockTest.php
+++ b/tests/Unit/NodeRenderer/EmbeddedEntryBlockTest.php
@@ -11,9 +11,10 @@ declare(strict_types=1);
 
 namespace Contentful\Tests\RichText\Unit\NodeRenderer;
 
+use Contentful\Core\Api\Link;
 use Contentful\RichText\Node\EmbeddedEntryBlock as NodeClass;
 use Contentful\RichText\NodeRenderer\EmbeddedEntryBlock;
-use Contentful\Tests\RichText\Implementation\Entry;
+use Contentful\Tests\RichText\Implementation\LinkResolver;
 use Contentful\Tests\RichText\Implementation\Node;
 use Contentful\Tests\RichText\Implementation\Renderer;
 use Contentful\Tests\RichText\TestCase;
@@ -24,7 +25,8 @@ class EmbeddedEntryBlockTest extends TestCase
     {
         $renderer = new Renderer();
         $nodeRenderer = new EmbeddedEntryBlock();
-        $node = new NodeClass([], new Entry('entryId'));
+
+        $node = new NodeClass([], new Link('entryId', 'Entry'), new LinkResolver());
 
         $this->assertTrue($nodeRenderer->supports($node));
         $this->assertFalse($nodeRenderer->supports(new Node('Some value')));

--- a/tests/Unit/NodeRenderer/EmbeddedEntryBlockTest.php
+++ b/tests/Unit/NodeRenderer/EmbeddedEntryBlockTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/EmbeddedEntryInlineTest.php
+++ b/tests/Unit/NodeRenderer/EmbeddedEntryInlineTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/EmbeddedEntryInlineTest.php
+++ b/tests/Unit/NodeRenderer/EmbeddedEntryInlineTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Contentful\Tests\RichText\Unit\NodeRenderer;
 
 use Contentful\RichText\Node\EmbeddedEntryInline as NodeClass;
+use Contentful\RichText\NodeMapper\Reference\StaticEntryReference;
 use Contentful\RichText\NodeRenderer\EmbeddedEntryInline;
 use Contentful\Tests\RichText\Implementation\Entry;
 use Contentful\Tests\RichText\Implementation\Node;
@@ -24,7 +25,7 @@ class EmbeddedEntryInlineTest extends TestCase
     {
         $renderer = new Renderer();
         $nodeRenderer = new EmbeddedEntryInline();
-        $node = new NodeClass([], new Entry('entryId'));
+        $node = new NodeClass([], new StaticEntryReference(new Entry('entryId')));
 
         $this->assertTrue($nodeRenderer->supports($node));
         $this->assertFalse($nodeRenderer->supports(new Node('Some value')));

--- a/tests/Unit/NodeRenderer/EntryHyperlinkTest.php
+++ b/tests/Unit/NodeRenderer/EntryHyperlinkTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/EntryHyperlinkTest.php
+++ b/tests/Unit/NodeRenderer/EntryHyperlinkTest.php
@@ -26,7 +26,7 @@ class EntryHyperlinkTest extends TestCase
         $renderer = new Renderer();
         $nodeRenderer = new EntryHyperlink();
         $nodes = $this->createNodes(1);
-        $node = new NodeClass($nodes, 'Entry title', new StaticEntryReference(new Entry('entryId')));
+        $node = new NodeClass($nodes, new StaticEntryReference(new Entry('entryId')), 'Entry title');
 
         $this->assertTrue($nodeRenderer->supports($node));
         $this->assertFalse($nodeRenderer->supports(new Node('Some value')));

--- a/tests/Unit/NodeRenderer/EntryHyperlinkTest.php
+++ b/tests/Unit/NodeRenderer/EntryHyperlinkTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Contentful\Tests\RichText\Unit\NodeRenderer;
 
 use Contentful\RichText\Node\EntryHyperlink as NodeClass;
+use Contentful\RichText\NodeMapper\Reference\StaticEntryReference;
 use Contentful\RichText\NodeRenderer\EntryHyperlink;
 use Contentful\Tests\RichText\Implementation\Entry;
 use Contentful\Tests\RichText\Implementation\Node;
@@ -25,7 +26,7 @@ class EntryHyperlinkTest extends TestCase
         $renderer = new Renderer();
         $nodeRenderer = new EntryHyperlink();
         $nodes = $this->createNodes(1);
-        $node = new NodeClass($nodes, new Entry('entryId'), 'Entry title');
+        $node = new NodeClass($nodes, 'Entry title', new StaticEntryReference(new Entry('entryId')));
 
         $this->assertTrue($nodeRenderer->supports($node));
         $this->assertFalse($nodeRenderer->supports(new Node('Some value')));

--- a/tests/Unit/NodeRenderer/Heading1Test.php
+++ b/tests/Unit/NodeRenderer/Heading1Test.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/Heading2Test.php
+++ b/tests/Unit/NodeRenderer/Heading2Test.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/Heading3Test.php
+++ b/tests/Unit/NodeRenderer/Heading3Test.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/Heading4Test.php
+++ b/tests/Unit/NodeRenderer/Heading4Test.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/Heading5Test.php
+++ b/tests/Unit/NodeRenderer/Heading5Test.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/Heading6Test.php
+++ b/tests/Unit/NodeRenderer/Heading6Test.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/HrTest.php
+++ b/tests/Unit/NodeRenderer/HrTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/HyperlinkTest.php
+++ b/tests/Unit/NodeRenderer/HyperlinkTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/ListItemTest.php
+++ b/tests/Unit/NodeRenderer/ListItemTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/NothingTest.php
+++ b/tests/Unit/NodeRenderer/NothingTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/OrderedListTest.php
+++ b/tests/Unit/NodeRenderer/OrderedListTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/ParagraphTest.php
+++ b/tests/Unit/NodeRenderer/ParagraphTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/TextTest.php
+++ b/tests/Unit/NodeRenderer/TextTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/NodeRenderer/UnorderedListTest.php
+++ b/tests/Unit/NodeRenderer/UnorderedListTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -117,9 +117,6 @@ class ParserTest extends TestCase
             ['asset-hyperlink'],
             ['embedded-asset-block'],
             ['embedded-asset-inline'],
-            ['embedded-entry-block'],
-            ['embedded-entry-inline'],
-            ['entry-hyperlink'],
         ];
     }
 

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -111,12 +111,39 @@ class ParserTest extends TestCase
         $this->assertJsonFixtureEqualsJsonObject($file.'.json', $node);
     }
 
+    /**
+     * @dataProvider provideInvalidDeferredResolvedLinkNodes
+     */
+    public function testMapperDeferredReferenceResolution(string $file, string $nodeClass)
+    {
+        $parser = new Parser(new FailingLinkResolver());
+
+        /** @var NodeClass\EntryHyperlink|NodeClass\EmbeddedEntryBlock|NodeClass\EmbeddedEntryInline $node */
+        $node = $parser->parse($this->getParsedFixture($file.'.json'));
+
+        $this->assertInstanceOf($nodeClass, $node);
+
+        /** @see FailingLinkResolver::resolveLink */
+        $this->expectException(\Exception::class);
+
+        $node->getEntry();
+    }
+
     public function provideInvalidLinkNodes(): array
     {
         return [
             ['asset-hyperlink'],
             ['embedded-asset-block'],
             ['embedded-asset-inline'],
+        ];
+    }
+
+    public function provideInvalidDeferredResolvedLinkNodes(): array
+    {
+        return [
+            ['embedded-entry-block', NodeClass\EmbeddedEntryBlock::class],
+            ['embedded-entry-inline', NodeClass\EmbeddedEntryInline::class],
+            ['entry-hyperlink', NodeClass\EntryHyperlink::class],
         ];
     }
 

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Contentful\Tests\RichText\Unit;
 
+use Contentful\Core\Resource\EntryInterface;
 use Contentful\RichText\Node as NodeClass;
 use Contentful\RichText\Parser;
 use Contentful\Tests\RichText\Implementation\FailingLinkResolver;
@@ -158,5 +159,31 @@ class ParserTest extends TestCase
 
         $this->assertInstanceOf(Node::class, $node);
         $this->assertSame('Node value', $node->getValue());
+    }
+
+    public function testParseInvalidLinkType()
+    {
+        $parser = new Parser(new FailingLinkResolver());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $parser->parse($this->getParsedFixture('embedded-invalid-link-type.json'));
+    }
+
+    public function testGettingResolvedEntry()
+    {
+        $parser = new Parser(new LinkResolver());
+
+        /** @var NodeClass\EntryHyperlink|NodeClass\EmbeddedEntryBlock|NodeClass\EmbeddedEntryInline $node */
+        $node = $parser->parse($this->getParsedFixture('embedded-entry-block.json'));
+
+        //$this->assertInstanceOf($nodeClass, $node);
+
+        /* @see FailingLinkResolver::resolveLink */
+        //$this->expectException(\Exception::class);
+
+        $entry = $node->getEntry();
+        $this->assertInstanceOf(EntryInterface::class, $entry);
+        $entry = $node->getEntry();
+        $this->assertInstanceOf(EntryInterface::class, $entry);
     }
 }

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 
@@ -123,7 +123,7 @@ class ParserTest extends TestCase
 
         $this->assertInstanceOf($nodeClass, $node);
 
-        /** @see FailingLinkResolver::resolveLink */
+        /* @see FailingLinkResolver::resolveLink */
         $this->expectException(\Exception::class);
 
         $node->getEntry();

--- a/tests/Unit/RendererTest.php
+++ b/tests/Unit/RendererTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the contentful/rich-text package.
  *
- * @copyright 2015-2019 Contentful GmbH
+ * @copyright 2015-2020 Contentful GmbH
  * @license   MIT
  */
 


### PR DESCRIPTION
@matthew-contentful , this is a bigger one. Full story is at https://github.com/contentful/rich-text.php/issues/43 . 

The Delivery Client fetches an entry, builds it and then saves it into resource pool and into cache backend at the same time. So we want the entry to be complete at this stage -- everything that should be fetched has to be fetched before storing into pool/cache.

This means that we cannot fetch all entry nested references recursively before storing it, as long as Contentful allows us to have reference loops.

So the only way to store entry is to not fetch all references upfront. But postpone that after an entry is pooled, cached and then being used.

This issue is specific to the php parser, i.e. I did not find an equivalent in other libs. It is a change in interfaces so this will be a major version, although all of it related to something that's not documented one way or another. I don't think there is a lower impact solution we can find here.