### PR TITLE
fix: HTML-encode renderer attributes and block dangerous URI schemes [AIS-260–262]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/contentful/rich-text.php/compare/4.0.3...HEAD)
 
+### Security
+
+* Fixed stored XSS in the `Hyperlink`, `AssetHyperlink`, and `EntryHyperlink` renderers: attribute values (href, title, asset/entry IDs) are now HTML-encoded, and `Hyperlink` hrefs are restricted to an allow-list of URI schemes (`http`, `https`, `mailto`, `tel`). Any other scheme — as well as protocol-relative (`//host`) URIs — now renders as `href="#"`. **Behavior change:** hyperlinks using schemes outside this allow-list (e.g. `ftp:`) will no longer render their original href.
+
 ## [4.0.3](https://github.com/contentful/rich-text.php/tree/4.0.3) (2025-11-18)
 
 * Added support for strikethrough mark

--- a/src/NodeRenderer/AssetHyperlink.php
+++ b/src/NodeRenderer/AssetHyperlink.php
@@ -31,8 +31,8 @@ class AssetHyperlink implements NodeRendererInterface
 
         return \sprintf(
             '<a href="#Asset-%s" title="%s">%s</a>',
-            $node->getAsset()->getId(),
-            $node->getTitle(),
+            \htmlspecialchars($node->getAsset()->getId(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
+            \htmlspecialchars($node->getTitle(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
             $renderer->renderCollection($node->getContent(), $context)
         );
     }

--- a/src/NodeRenderer/AssetHyperlink.php
+++ b/src/NodeRenderer/AssetHyperlink.php
@@ -31,8 +31,8 @@ class AssetHyperlink implements NodeRendererInterface
 
         return \sprintf(
             '<a href="#Asset-%s" title="%s">%s</a>',
-            \htmlspecialchars($node->getAsset()->getId(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
-            \htmlspecialchars($node->getTitle(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
+            htmlspecialchars($node->getAsset()->getId(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
+            htmlspecialchars($node->getTitle(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
             $renderer->renderCollection($node->getContent(), $context)
         );
     }

--- a/src/NodeRenderer/EntryHyperlink.php
+++ b/src/NodeRenderer/EntryHyperlink.php
@@ -31,8 +31,8 @@ class EntryHyperlink implements NodeRendererInterface
 
         return \sprintf(
             '<a href="#Entry-%s" title="%s">%s</a>',
-            \htmlspecialchars($node->getEntry()->getId(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
-            \htmlspecialchars($node->getTitle(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
+            htmlspecialchars($node->getEntry()->getId(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
+            htmlspecialchars($node->getTitle(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
             $renderer->renderCollection($node->getContent(), $context)
         );
     }

--- a/src/NodeRenderer/EntryHyperlink.php
+++ b/src/NodeRenderer/EntryHyperlink.php
@@ -31,8 +31,8 @@ class EntryHyperlink implements NodeRendererInterface
 
         return \sprintf(
             '<a href="#Entry-%s" title="%s">%s</a>',
-            $node->getEntry()->getId(),
-            $node->getTitle(),
+            \htmlspecialchars($node->getEntry()->getId(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
+            \htmlspecialchars($node->getTitle(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
             $renderer->renderCollection($node->getContent(), $context)
         );
     }

--- a/src/NodeRenderer/Hyperlink.php
+++ b/src/NodeRenderer/Hyperlink.php
@@ -29,10 +29,16 @@ class Hyperlink implements NodeRendererInterface
             throw new \LogicException(\sprintf('Trying to use node renderer "%s" to render unsupported node of class "%s".', static::class, $node::class));
         }
 
+        $uri = $node->getUri();
+        $scheme = \strtolower((string) \parse_url($uri, \PHP_URL_SCHEME));
+        $safeUri = \in_array($scheme, ['https', 'http', ''], true)
+            ? \htmlspecialchars($uri, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8')
+            : '#';
+
         return \sprintf(
             '<a href="%s" title="%s">%s</a>',
-            $node->getUri(),
-            $node->getTitle(),
+            $safeUri,
+            \htmlspecialchars($node->getTitle(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
             $renderer->renderCollection($node->getContent(), $context)
         );
     }

--- a/src/NodeRenderer/Hyperlink.php
+++ b/src/NodeRenderer/Hyperlink.php
@@ -29,17 +29,31 @@ class Hyperlink implements NodeRendererInterface
             throw new \LogicException(\sprintf('Trying to use node renderer "%s" to render unsupported node of class "%s".', static::class, $node::class));
         }
 
-        $uri = $node->getUri();
-        $scheme = \strtolower((string) \parse_url($uri, \PHP_URL_SCHEME));
-        $safeUri = \in_array($scheme, ['https', 'http', ''], true)
-            ? \htmlspecialchars($uri, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8')
-            : '#';
-
         return \sprintf(
             '<a href="%s" title="%s">%s</a>',
-            $safeUri,
+            $this->sanitizeUri($node->getUri()),
             \htmlspecialchars($node->getTitle(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
             $renderer->renderCollection($node->getContent(), $context)
         );
+    }
+
+    /**
+     * Returns an HTML-safe href value, blocking any scheme other than http(s).
+     *
+     * Control characters and whitespace are stripped before scheme detection
+     * because browsers ignore them when resolving a URL (e.g. "java\tscript:"),
+     * so leaving them in would let \parse_url() report an empty scheme and wave
+     * a dangerous URI through.
+     */
+    private function sanitizeUri(string $uri): string
+    {
+        $normalized = \preg_replace('/[\x00-\x20\x7f]+/', '', $uri) ?? '';
+        $scheme = \strtolower((string) \parse_url($normalized, \PHP_URL_SCHEME));
+
+        if (!\in_array($scheme, ['https', 'http', ''], true)) {
+            return '#';
+        }
+
+        return \htmlspecialchars($normalized, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
     }
 }

--- a/src/NodeRenderer/Hyperlink.php
+++ b/src/NodeRenderer/Hyperlink.php
@@ -32,7 +32,7 @@ class Hyperlink implements NodeRendererInterface
         return \sprintf(
             '<a href="%s" title="%s">%s</a>',
             $this->sanitizeUri($node->getUri()),
-            \htmlspecialchars($node->getTitle(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
+            htmlspecialchars($node->getTitle(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
             $renderer->renderCollection($node->getContent(), $context)
         );
     }
@@ -47,13 +47,13 @@ class Hyperlink implements NodeRendererInterface
      */
     private function sanitizeUri(string $uri): string
     {
-        $normalized = \preg_replace('/[\x00-\x20\x7f]+/', '', $uri) ?? '';
-        $scheme = \strtolower((string) \parse_url($normalized, \PHP_URL_SCHEME));
+        $normalized = preg_replace('/[\x00-\x20\x7f]+/', '', $uri) ?? '';
+        $scheme = mb_strtolower((string) parse_url($normalized, \PHP_URL_SCHEME));
 
         if (!\in_array($scheme, ['https', 'http', ''], true)) {
             return '#';
         }
 
-        return \htmlspecialchars($normalized, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+        return htmlspecialchars($normalized, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
     }
 }

--- a/src/NodeRenderer/Hyperlink.php
+++ b/src/NodeRenderer/Hyperlink.php
@@ -38,19 +38,35 @@ class Hyperlink implements NodeRendererInterface
     }
 
     /**
-     * Returns an HTML-safe href value, blocking any scheme other than http(s).
+     * Allow-list of URI schemes safe to emit as an href. Relative and
+     * fragment-only URIs (which carry no scheme) are also permitted.
+     */
+    private const ALLOWED_SCHEMES = ['https', 'http', 'mailto', 'tel'];
+
+    /**
+     * Returns an HTML-safe href value, blocking any scheme outside the
+     * allow-list as well as protocol-relative URIs.
      *
      * Control characters and whitespace are stripped before scheme detection
      * because browsers ignore them when resolving a URL (e.g. "java\tscript:"),
-     * so leaving them in would let \parse_url() report an empty scheme and wave
-     * a dangerous URI through.
+     * so leaving them in would let a dangerous URI slip through.
      */
     private function sanitizeUri(string $uri): string
     {
         $normalized = preg_replace('/[\x00-\x20\x7f]+/', '', $uri) ?? '';
-        $scheme = mb_strtolower((string) parse_url($normalized, \PHP_URL_SCHEME));
 
-        if (!\in_array($scheme, ['https', 'http', ''], true)) {
+        // Reject protocol-relative URIs ("//evil.com/..."). They carry no
+        // scheme, so they'd otherwise pass the allow-list as a scheme-less
+        // relative URI, giving an open-redirect / phishing vector.
+        if (str_starts_with($normalized, '//')) {
+            return '#';
+        }
+
+        // Match the scheme directly rather than delegating to parse_url(),
+        // which returns false/null on malformed input — both coerce to an
+        // empty ("safe") scheme and would wave a crafted URI through.
+        if (preg_match('/^([a-zA-Z][a-zA-Z0-9+.\-]*):/', $normalized, $matches)
+            && !\in_array(mb_strtolower($matches[1]), self::ALLOWED_SCHEMES, true)) {
             return '#';
         }
 

--- a/tests/Unit/NodeRenderer/AssetHyperlinkTest.php
+++ b/tests/Unit/NodeRenderer/AssetHyperlinkTest.php
@@ -33,6 +33,20 @@ class AssetHyperlinkTest extends TestCase
         $this->assertRegExp('/\<a href\=\"\#Asset-assetId\" title\=\"Asset title\"\>([a-zA-Z0-9]{10})\<\/a\>/', $nodeRenderer->render($renderer, $node));
     }
 
+    public function testTitleAndAssetIdAreEscaped(): void
+    {
+        $renderer = new Renderer();
+        $nodeRenderer = new AssetHyperlink();
+        $node = new NodeClass($this->createNodes(1), new Asset('"><script>alert(1)</script>'), '" onmouseover="alert(1)');
+
+        $rendered = $nodeRenderer->render($renderer, $node);
+
+        $this->assertStringContainsString('title="&quot; onmouseover=&quot;alert(1)"', $rendered);
+        $this->assertStringContainsString('#Asset-&quot;&gt;&lt;script&gt;', $rendered);
+        $this->assertStringNotContainsString('<script>', $rendered);
+        $this->assertStringNotContainsString('onmouseover="alert', $rendered);
+    }
+
     public function testInvalidNodeRendered(): void
     {
         $this->expectException(\LogicException::class);

--- a/tests/Unit/NodeRenderer/EntryHyperlinkTest.php
+++ b/tests/Unit/NodeRenderer/EntryHyperlinkTest.php
@@ -34,6 +34,20 @@ class EntryHyperlinkTest extends TestCase
         $this->assertRegExp('/\<a href\=\"\#Entry-entryId\" title\=\"Entry title\"\>([a-zA-Z0-9]{10})\<\/a\>/', $nodeRenderer->render($renderer, $node));
     }
 
+    public function testTitleAndEntryIdAreEscaped(): void
+    {
+        $renderer = new Renderer();
+        $nodeRenderer = new EntryHyperlink();
+        $node = new NodeClass($this->createNodes(1), new StaticEntryReference(new Entry('"><script>alert(1)</script>')), '" onmouseover="alert(1)');
+
+        $rendered = $nodeRenderer->render($renderer, $node);
+
+        $this->assertStringContainsString('title="&quot; onmouseover=&quot;alert(1)"', $rendered);
+        $this->assertStringContainsString('#Entry-&quot;&gt;&lt;script&gt;', $rendered);
+        $this->assertStringNotContainsString('<script>', $rendered);
+        $this->assertStringNotContainsString('onmouseover="alert', $rendered);
+    }
+
     public function testInvalidNodeRendered(): void
     {
         $this->expectException(\LogicException::class);

--- a/tests/Unit/NodeRenderer/HyperlinkTest.php
+++ b/tests/Unit/NodeRenderer/HyperlinkTest.php
@@ -59,6 +59,8 @@ class HyperlinkTest extends TestCase
             'leading control char' => ["\x01javascript:alert(1)"],
             'data uri' => ['data:text/html,<script>alert(1)</script>'],
             'vbscript' => ['vbscript:msgbox(1)'],
+            'protocol-relative' => ['//attacker.com/phish'],
+            'protocol-relative with control char' => ["/\t/attacker.com/phish"],
         ];
     }
 
@@ -82,6 +84,8 @@ class HyperlinkTest extends TestCase
             'relative path' => ['/some/path', '/some/path'],
             'fragment' => ['#anchor', '#anchor'],
             'query preserved and escaped' => ['https://example.com/?a=1&b=2', 'https://example.com/?a=1&amp;b=2'],
+            'mailto' => ['mailto:hello@contentful.com', 'mailto:hello@contentful.com'],
+            'tel' => ['tel:+1-555-0100', 'tel:+1-555-0100'],
         ];
     }
 

--- a/tests/Unit/NodeRenderer/HyperlinkTest.php
+++ b/tests/Unit/NodeRenderer/HyperlinkTest.php
@@ -35,7 +35,7 @@ class HyperlinkTest extends TestCase
     /**
      * @dataProvider dangerousUriProvider
      */
-    public function testDangerousSchemesAreNeutralized(string $uri)
+    public function testDangerousSchemesAreNeutralized(string $uri): void
     {
         $renderer = new Renderer();
         $nodeRenderer = new Hyperlink();
@@ -65,7 +65,7 @@ class HyperlinkTest extends TestCase
     /**
      * @dataProvider safeUriProvider
      */
-    public function testSafeSchemesArePreserved(string $uri, string $expectedHref)
+    public function testSafeSchemesArePreserved(string $uri, string $expectedHref): void
     {
         $renderer = new Renderer();
         $nodeRenderer = new Hyperlink();

--- a/tests/Unit/NodeRenderer/HyperlinkTest.php
+++ b/tests/Unit/NodeRenderer/HyperlinkTest.php
@@ -32,6 +32,59 @@ class HyperlinkTest extends TestCase
         $this->assertRegExp('/\<a href\=\"https\:\/\/www\.contentful\.com\" title\=\"Contentful\"\>([a-zA-Z0-9]{10})\<\/a\>/', $nodeRenderer->render($renderer, $node));
     }
 
+    /**
+     * @dataProvider dangerousUriProvider
+     */
+    public function testDangerousSchemesAreNeutralized(string $uri)
+    {
+        $renderer = new Renderer();
+        $nodeRenderer = new Hyperlink();
+        $node = new NodeClass($this->createNodes(1), $uri, 'Contentful');
+
+        $rendered = $nodeRenderer->render($renderer, $node);
+
+        $this->assertStringContainsString('href="#"', $rendered);
+        $this->assertStringNotContainsStringIgnoringCase('javascript', $rendered);
+    }
+
+    public function dangerousUriProvider(): array
+    {
+        return [
+            'plain javascript' => ['javascript:alert(1)'],
+            'uppercase javascript' => ['JavaScript:alert(1)'],
+            'leading space' => [' javascript:alert(1)'],
+            'leading tab' => ["\tjavascript:alert(1)"],
+            'embedded tab' => ["java\tscript:alert(1)"],
+            'embedded newline' => ["java\nscript:alert(1)"],
+            'leading control char' => ["\x01javascript:alert(1)"],
+            'data uri' => ['data:text/html,<script>alert(1)</script>'],
+            'vbscript' => ['vbscript:msgbox(1)'],
+        ];
+    }
+
+    /**
+     * @dataProvider safeUriProvider
+     */
+    public function testSafeSchemesArePreserved(string $uri, string $expectedHref)
+    {
+        $renderer = new Renderer();
+        $nodeRenderer = new Hyperlink();
+        $node = new NodeClass($this->createNodes(1), $uri, 'Contentful');
+
+        $this->assertStringContainsString('href="'.$expectedHref.'"', $nodeRenderer->render($renderer, $node));
+    }
+
+    public function safeUriProvider(): array
+    {
+        return [
+            'https' => ['https://www.contentful.com', 'https://www.contentful.com'],
+            'http' => ['http://example.com', 'http://example.com'],
+            'relative path' => ['/some/path', '/some/path'],
+            'fragment' => ['#anchor', '#anchor'],
+            'query preserved and escaped' => ['https://example.com/?a=1&b=2', 'https://example.com/?a=1&amp;b=2'],
+        ];
+    }
+
     public function testInvalidNodeRendered(): void
     {
         $this->expectException(\LogicException::class);


### PR DESCRIPTION
## Summary

- `Hyperlink::render` now HTML-escapes `$node->getUri()` (via `htmlspecialchars`) and enforces an `http`/`https`-only scheme allow-list; also escapes `$node->getTitle()` (AIS-260)
- `AssetHyperlink::render` escapes `$node->getTitle()` and the asset ID (AIS-261)
- `EntryHyperlink::render` escapes `$node->getTitle()` and the entry ID (AIS-262)

All three renderers used unescaped `sprintf` interpolation into HTML attributes, allowing stored XSS via attacker-controlled rich-text fields.

## Tickets

Closes AIS-260, AIS-261, AIS-262

## Test plan

- [ ] `composer test` passes (pre-existing `EmbeddedImage` null failure unrelated to this change)
- [ ] Verify `title="\" onmouseover=..."` is safely encoded in rendered output
- [ ] Verify `javascript:` href in Hyperlink renders as `#`

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR patches critical stored XSS vulnerabilities in the Hyperlink, AssetHyperlink, and EntryHyperlink renderer classes. The renderers previously used unsafe sprintf() interpolation into HTML attributes, allowing stored XSS via attacker-controlled rich-text fields. All attribute values are now HTML-encoded using htmlspecialchars(), and the Hyperlink renderer enforces a strict URI scheme allowlist (http, https, mailto, tel) while rejecting protocol-relative URIs.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Fixes stored XSS in Hyperlink.php by adding htmlspecialchars escaping for href and title attributes, implementing a sanitizeUri() method that allows only http/https/mailto/tel schemes, and rejecting protocol-relative URIs ('//host') to prevent open-redirect attacks</li>

<li>Fixes stored XSS in AssetHyperlink.php by adding htmlspecialchars escaping with ENT_QUOTES|ENT_SUBSTITUTE flags for the asset ID and title attributes</li>

<li>Fixes stored XSS in EntryHyperlink.php by adding htmlspecialchars escaping with ENT_QUOTES|ENT_SUBSTITUTE flags for the entry ID and title attributes</li>

<li>Adds comprehensive test coverage including dangerous scheme neutralization tests (11 variants covering javascript, data:, vbscript, protocol-relative, control characters) and safe scheme preservation tests (7 cases including mailto, tel, HTML entity escaping)</li>

</ul>
</details>

</div>